### PR TITLE
Add salt to task ID computation (*)

### DIFF
--- a/draft-wang-ppm-dap-taskprov.md
+++ b/draft-wang-ppm-dap-taskprov.md
@@ -142,7 +142,7 @@ When the client uses the Taskbind extension, it computes the task ID ({{Section
 4.2 of !DAP}}) as follows:
 
 ~~~
-task_id = SHA-256(task_config)
+task_id = SHA-256(SHA-256("dap-taskprov task id") || task_config)
 ~~~
 
 where `task_config` is a `TaskConfig` structure defined in {{task-encoding}}.
@@ -384,18 +384,17 @@ The VDAF verification key used for the task is computed as follows:
 ~~~
 verify_key = HKDF-Expand(
     HKDF-Extract(
-        taskprov_salt,   # salt
-        verify_key_init, # IKM
+        SHA-256("dap-taskprov"), # salt
+        verify_key_init,         # IKM
     ),
-    task_id,             # info
-    VERIFY_KEY_SIZE,     # L
+    task_id,                     # info
+    VERIFY_KEY_SIZE,             # L
 )
 ~~~
 
-where `taskprov_salt` is defined to be the SHA-256 hash of the octet string
-"dap-taskprov" and `task_id` is as defined in {{definition}}. Functions
-HKDF-Extract() and HKDF-Expand() are as defined in {{!RFC5869}}. Both functions
-are instantiated with SHA-256.
+where `task_id` is as defined in {{definition}}. Functions HKDF-Extract() and
+HKDF-Expand() are as defined in {{!RFC5869}}. Both functions are instantiated
+with SHA-256.
 
 ## Opting into a Task {#provisioning-a-task}
 


### PR DESCRIPTION
Closes #64.

Current the task ID is computed by hashing the raw `TaskConfig`. Prepend the `TaskConfig` with a salt string so that it's less likely we'll confuse the task ID with the hash of the task config in a different context.