### PR TITLE
Prepare to cut draft 01

### DIFF
--- a/draft-ietf-ppm-dap-taskprov.md
+++ b/draft-ietf-ppm-dap-taskprov.md
@@ -61,11 +61,11 @@ provisioning that builds on the report extension.
 (RFC EDITOR: Remove this paragraph.) This draft is maintained in
 https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap-taskprov.
 
-The DAP protocol {{!DAP=I-D.draft-ietf-ppm-dap-12}} enables secure aggregation
+The DAP protocol {{!DAP=I-D.draft-ietf-ppm-dap-13}} enables secure aggregation
 of a set of reports submitted by Clients. This process is centered around a
 "task" that determines, among other things, the cryptographic scheme to use for
 the secure computation (a Verifiable Distributed Aggregation Function
-{{!VDAF=I-D.draft-irtf-cfrg-vdaf-12}}), how reports are partitioned into
+{{!VDAF=I-D.draft-irtf-cfrg-vdaf-13}}), how reports are partitioned into
 batches, and privacy parameters such as the minimum size of each batch. See
 {{Section 4.3 of !DAP}} for a complete listing.
 
@@ -130,6 +130,10 @@ to implement the DAP report extension in {{definition}}.
 
 - Task provisioning: Remove guidance for per-task HPKE configurations, as this
   feature was deprecated by DAP.
+
+- Bump draft-ietf-ppm-dap-12 to 13 {{!DAP}}. (\*)
+
+- Bump draft-irtf-cfrg-vdaf-12 to 13 {{!VDAF}}.
 
 # Conventions and Definitions
 

--- a/draft-ietf-ppm-dap-taskprov.md
+++ b/draft-ietf-ppm-dap-taskprov.md
@@ -103,6 +103,34 @@ make task configuration completely in-band, via HTTP request headers. Note that
 this mechanism is an optional feature of this specification; it is not required
 to implement the DAP report extension in {{definition}}.
 
+## Change Log
+
+(RFC EDITOR: Remove this section.)
+
+(\*) Indicates a change that breaks wire compatibility with the previous draft.
+
+01:
+
+- Add an extension point to the `TaskConfig` structure and define rules for
+  processing extensions. (\*)
+
+- Remove DP mechanisms. (\*)
+
+- Add guidelines for extending this document to account for new VDAFs or DAP
+  batch modes. Improve the extension points for these in `TaskConfig` in order
+  to make this easier. (\*)
+
+- Add a salt to the task ID computation. (\*)
+
+- Harmonize task lifetime parameters with {{!DAP}} by adding a task start time
+  and replacing the task end time with a task duration. (\*)
+
+- Harmonize batch mode parameters with {{!DAP}} by removing the deprecated
+  `max_batch_query_count` and `max_batch_size` parameters. (\*)
+
+- Task provisioning: Remove guidance for per-task HPKE configurations, as this
+  feature was deprecated by DAP.
+
 # Conventions and Definitions
 
 {::boilerplate bcp14-tagged}


### PR DESCRIPTION
Stacked on #91.

* Pass of draft:
  * Update section references.
  * Improve precision of terminology.
  * Remove the "Supporting HPKE Configurations Independent of Tasks" section. This is no longer relevant since we removed support of per-task HPKE configs in DAP draft 12.
  * Fix a few typos and minor grammar issues.
  * In Security Considerations we recommend digitally signing the task config; mention that we can do this with a Taskbind extension.
* Add a change log.
* Bump base drafts.
