### PR TITLE
Tweak lower bounds on field lengths to 0 instead of 1.

### DIFF
--- a/draft-ietf-ppm-dap-taskprov.md
+++ b/draft-ietf-ppm-dap-taskprov.md
@@ -230,10 +230,9 @@ struct {
 
     /* The batch mode and its parameters. */
     BatchMode batch_mode;
-    opaque batch_config<1..2^16-1>;
+    opaque batch_config<0..2^16-1>;
 
     /* The earliest timestamp that will be accepted for this task. */
-       task. */
     Time task_start;
 
     /* The duration of the task. */
@@ -241,7 +240,7 @@ struct {
 
     /* Determines the VDAF type and its config parameters. */
     VdafType vdaf_type;
-    opaque vdaf_config<1..2^16-1>;
+    opaque vdaf_config<0..2^16-1>;
 
     /* Taskbind Extensions. */
     TaskbindExtension extensions<0..2^16-1>;


### PR DESCRIPTION
Both of the relevant fields can include zero-length values in some cases, so this change is required for taskprov to be implementable (while still following the specification).

Also, clean up a comment typo.