### PR TITLE
Fix references

### DIFF
--- a/draft-ietf-ppm-dap-taskprov.md
+++ b/draft-ietf-ppm-dap-taskprov.md
@@ -80,7 +80,7 @@ agreement on the task parameters. On the other hand, disagreement between a
 Client and the Aggregators should prevent reports uploaded by that Client from
 being processed.
 
-{{definition}} specifies a report extension ({{Section 4.4.3 of !DAP}}) that
+{{definition}} specifies a report extension ({{Section 4.5.3 of !DAP}}) that
 endows DAP with this property. First, it specifies an encoding of all task
 parameters that are relevant to all parties. This excludes cryptographic
 assets, such as the secret VDAF verification key ({{Section 5 of !VDAF}}) or
@@ -160,7 +160,7 @@ Task author:
 # The Taskbind Extension {#definition}
 
 To use the Taskbind extension, the Client includes the following extension in
-the report extensions for each Aggregator as described in {{Section 4.4.3 of
+the report extensions for each Aggregator as described in {{Section 4.5.3 of
 !DAP}}:
 
 ~~~

--- a/draft-ietf-ppm-dap-taskprov.md
+++ b/draft-ietf-ppm-dap-taskprov.md
@@ -297,7 +297,7 @@ The definition of `Time`, `Duration`, `Url`, and `BatchMode` follow those in
 This section defines the payload of `TaskConfig.vdaf_config` for each VDAF
 specified in {{!VDAF}}. In some cases, the VDAF supports more than two
 Aggregators; but since DAP only supports two Aggregators, we do not include the
-number of Aggregators in the encoding (cf. {{Section C of !VDAF}}).
+number of Aggregators in the encoding (cf. {{Section 7 of !VDAF}}).
 
 ### Prio3Count
 

--- a/draft-ietf-ppm-dap-taskprov.md
+++ b/draft-ietf-ppm-dap-taskprov.md
@@ -685,7 +685,7 @@ creation of a new registry for Taskbind extensions.
 
 The following entry will be (RFC EDITOR: change "will be" to "has been") added
 to the "Report Extension Identifiers" registry of the "Distributed Aggregation
-Protocol (DAP)" page created by {{!VDAF}}:
+Protocol (DAP)" page created by {{!DAP}}:
 
 Value:
 : `0xff00`


### PR DESCRIPTION
This fixes a few editorial issues in references.

* One of the IANA considerations sections had a reference to VDAF that should instead be a reference to DAP.
* There was a reference to `{{Section C of !VDAF}}`. Appendix C is the test vectors. Based on context, I think this should have been a reference to the Prio3 section, so I changed it accordingly.
* I updated invalid section numbers pointing to the section of DAP discussing extensions.