### PR TITLE
Add TimePrecision type and redefine time_precision

### DIFF
--- a/draft-ietf-ppm-dap-taskprov.md
+++ b/draft-ietf-ppm-dap-taskprov.md
@@ -112,7 +112,7 @@ to implement the DAP report extension in {{definition}}.
 04:
 
 - Redefine `time_precision` as its own `TimePrecision` type, to maintain
-  compatibility with DAP-16 {{!DAP}}. (\*)
+  compatibility with DAP-16 {{!DAP}}.
 
 03:
 
@@ -126,7 +126,7 @@ to implement the DAP report extension in {{definition}}.
 
 - Add registration of the "DAP-Taskprov" to IANA considerations.
 
-- Bump draft-ietf-ppm-dap-13 to 16 {{!DAP}}.
+- Bump draft-ietf-ppm-dap-13 to 16 {{!DAP}}.  (\*)
 
 - Bump draft-irtf-cfrg-vdaf-13 to 15 {{!VDAF}}.
 


### PR DESCRIPTION
DAP-16 redefined Time, Duration (and by extension Interval) in terms
of multiples of the task's time_precision, making `Duration time_precision`
nonsensical in TaskProv. Since we do want to keep and use the new `Time`
and `Duration` definitions here, this adds a new `TimePrecision` type and
defines it simply, so the other types can depend on it.

I marked this change as breaking, though it really isn't -- but the impacts
from DAP-16 _are_, which I think this change effectuates.

Bikeshed: I considered calling the type `Seconds`, but that feels like
generality for generality's sake, while this is deliberately specific.

Fixes #110
