### PR TITLE
Remove task parameter binding from the draft

### DIFF
--- a/draft-ietf-ppm-dap-taskprov.md
+++ b/draft-ietf-ppm-dap-taskprov.md
@@ -59,21 +59,18 @@ parties that this mechanism was used to configure the task.
 (RFC EDITOR: Remove this paragraph.) This draft is maintained in
 https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap-taskprov.
 
-> TODO: update this DAP reference once draft-ietf-ppm-dap-18 is out
+The Distributed Aggregation Protocol {{!DAP=I-D.draft-ietf-ppm-dap-18}} enables
+secure aggregation of a set of reports submitted by Clients. This process is
+centered around a "task" that determines, among other things, the cryptographic
+scheme to use for the secure computation (a Verifiable Distributed Aggregation
+Function {{!VDAF=I-D.draft-irtf-cfrg-vdaf-15}}), how reports are partitioned
+into batches, and privacy parameters such as the minimum size of each batch.
 
-The DAP protocol {{!DAP=I-D.draft-ietf-ppm-dap-16}} enables secure aggregation
-of a set of reports submitted by Clients. This process is centered around a
-"task" that determines, among other things, the cryptographic scheme to use for
-the secure computation (a Verifiable Distributed Aggregation Function
-{{!VDAF=I-D.draft-irtf-cfrg-vdaf-15}}), how reports are partitioned into
-batches, and privacy parameters such as the minimum size of each batch. See
-{{todo-fix-dap-reference}} for a complete listing.
-
-{{taskprov}} specifies one possible mechanism for provisioning DAP tasks that
-is built on top of the task configuration definition in
-{{todo-fix-dap-reference}}. Its chief design goal is to make task configuration
-completely in-band, via HTTP request headers. It also defines a task extension
-that signals to parties that this mechanism was used to configure the task.
+{{taskprov}} specifies one possible mechanism for provisioning DAP tasks that is
+built on top of the task configuration definition in {{Section 4.2 of !DAP}}.
+Its chief design goal is to make task configuration completely in-band, via HTTP
+request headers. It also defines a task extension that signals to parties that
+this mechanism was used to configure the task.
 
 ## Change Log
 
@@ -166,29 +163,29 @@ Task author:
 
 When Taskprov is in use, protocol participants include a `Taskprov` extension
 (see {{task-extension}}) in the task's `TaskConfiguration` structure as
-described in {{todo-fix-dap-reference}}.
+described in {{Section 4.2 of !DAP}}.
 
 The payload of the extension MUST be empty. If the payload is non-empty, then
 the protocol participant MUST refuse to participate in the task.
 
-When the client uses the Taskprov extension, it computes the task ID
-({{todo-fix-dap-reference}}) as follows:
+When the client uses the Taskprov extension, it computes the task ID ({{Section
+4.2 of !DAP}}) as follows:
 
 ~~~
 task_id = SHA-256(SHA-256("dap-taskprov task id") || task_config)
 ~~~
 
-where `task_config` is a `TaskConfiguration` structure defined in
-{{todo-fix-dap-reference}}. Function SHA-256() is as defined in {{SHS}}.
+where `task_config` is a `TaskConfiguration` structure. Function SHA-256() is as
+defined in {{SHS}}.
 
 The task configuration is bound to each report share (via HPKE authenticated and
-associated data, see {{todo-fix-dap-reference}}). Deterministically deriving the
+associated data, see {{Section 4.4.2.1 of !DAP}}). Deterministically deriving the
 task ID from the encoded `TaskConfiguration` ensures that Clients, Aggregators
 and the Collector can only agree on the task ID if they also agree on the
 parameters, including whether Taskprov is in use. This is accomplished by the
 following Aggregator behavior.
 
-During aggregation ({{Section 4.6 of !DAP}}) in a task where Taskprov is in use,
+During aggregation ({{Section 4.5 of !DAP}}) in a task where Taskprov is in use,
 each Aggregator processes reports as follows.
 
 First, it looks up the ID and parameters associated with the task. Note the
@@ -196,11 +193,11 @@ task has already been configured; otherwise the Aggregator would have already
 aborted the request due to not recognizing the task.
 
 Next, the Aggregator encodes the parameters as a `TaskConfiguration` defined in
-{{todo-fix-dap-reference}} and computes the task ID as above. If the derived
-task ID does not match the task ID of the request, then it MUST reject the
-report with error "invalid_message".
+{{Section 4.2 of !DAP}} and computes the task ID as above. If the derived task
+ID does not match the task ID of the request, then it MUST reject the report
+with error "invalid_message".
 
-During the upload interaction ({{Section 4.5 of !DAP}}), the Leader SHOULD
+During the upload interaction ({{Section 4.4 of !DAP}}), the Leader SHOULD
 abort the request with "unrecognizedTask" if the derived task ID does not match
 the task ID of the request.
 
@@ -247,14 +244,14 @@ which in turn is presumed to be configured out-of-band.
 
 The process of provisioning a task begins when the Author disseminates the task
 configuration to the Collector and each of the Clients. When a Client issues an
-upload request to the Leader (as described in {{Section 4.5 of !DAP}}), it
+upload request to the Leader (as described in {{Section 4.4 of !DAP}}), it
 includes in an HTTP header the task configuration it used to generate the
 report. We refer to this process as "task advertisement". Before consuming the
 report, the Leader parses the configuration and decides whether to opt-in; if
 not, the task's execution halts.
 
 Otherwise, if the Leader does opt-in, it advertises the task to the Helper
-during the aggregation interaction ({{Section 4.6 of !DAP}}). In particular, it
+during the aggregation interaction ({{Section 4.5 of !DAP}}). In particular, it
 includes the task configuration in an HTTP header of each aggregation job
 request for that task. Before proceeding, the Helper must first parse the
 configuration and decide whether to opt-in; if not, the task's execution halts.
@@ -263,7 +260,7 @@ configuration and decide whether to opt-in; if not, the task's execution halts.
 
 To advertise a task to its peer, a protocol participant includes the header
 "DAP-Taskprov" with an HTTP request incident to the task execution. The value
-is the `TaskConfiguration` structure defined {{todo-fix-dap-reference}},
+is the `TaskConfiguration` structure defined in {{Section 4.2 of !DAP}},
 expanded into its URL-safe, unpadded Base 64 representation as specified in
 {{Sections 5 and 3.2 of !RFC4648}}.
 
@@ -316,12 +313,12 @@ A protocol participant MAY "opt out" of a task if:
    established.
 
 1. The task lifetime is too long (if the `task_interval` task extension is in
-   use; see {{todo-fix-dap-reference}}).
+   use; see {{Section 4.2.3 of !DAP}}).
 
 A protocol participant MUST opt out if:
 
 1. The task has ended (if the `task_interval` task extension is in use; see
-   {{todo-fix-dap-reference}}).
+   {{Section 4.2.3 of !DAP}}).
 
 1. The DAP batch mode or VDAF is not implemented.
 
@@ -407,9 +404,8 @@ First, the Helper attempts to parse payload of the "DAP-Taskprov" HTTP header.
 If this step fails, the Helper MUST abort with "invalidMessage".
 
 Next, the Helper checks that the task ID indicated in the request matches the
-task ID derived from the `TaskConfiguration` as defined in
-{{todo-fix-dap-reference}}. If not, the Helper MUST abort with
-"unrecognizedTask".
+task ID derived from the `TaskConfiguration` as defined in {{definition}}.
+If not, the Helper MUST abort with "unrecognizedTask".
 
 Next, the Helper decides whether to opt in to the task as described in
 {{provisioning-a-task}}. If it opts out, it MUST abort the request with
@@ -442,7 +438,7 @@ agreement on the task configuration. This is provided by binding the
 parameters to the task ID, which in turn is bound to each report uploaded for a
 task. Furthermore, inclusion of the Taskprov extension in the task configuration
 means Aggregators that do not implement this extension will reject the report as
-required by ({{Section 4.5.3 of !DAP}}).
+required by {{Section 4.2.2 of !DAP}}.
 
 The task provisioning mechanism in {{taskprov}} extends the threat model of DAP
 by including a new logical role, called the Author. The Author is responsible
@@ -470,8 +466,8 @@ directly impact tasks used by honest Clients, it does present a
 Denial-of-Service risk for the Aggregators themselves. This can be mitigated by
 limiting the rate at which new tasks are configured. In addition, deployments
 SHOULD arrange for the Author to digitally sign the task configuration so that
-Clients cannot forge task creation, e.g., via a task extension
-({{todo-fix-dap-reference}}).
+Clients cannot forge task creation, e.g., via a task extension ({{Section 4.2.2
+of !DAP}}).
 
 Support for the Taskprov extension may render a deployment of DAP more
 susceptible to task enumeration attacks ({{Section 8.6.1 of !DAP}}). For
@@ -481,7 +477,7 @@ uploading a report for it with the Taskprov extension. Aggregators can mitigate
 these kinds of attack by:
 
 1. Requiring authentication of all APIs, including the upload endpoint (see
-   {{Section 3.3 of !DAP}});
+   {{Section 3.5 of !DAP}});
 
 1. Enforcing rate limits on unauthenticated APIs; or
 
@@ -542,15 +538,6 @@ task-provisioning header:
 | DAP-Taskprov | permanent | {{taskprov}} of RFC XXXX |
 {: #http-header title="Updates to the Hypertext Transfer Protocol (HTTP) Field Name Registry"}
 
-# TODO fix DAP reference
-
-> TODO: delete this section
-
-This document should refer to sections of a DAP draft that includes
-https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/774 (this will probably
-be draft-ietf-ppm-dap-18). This section is a placeholder so we can refer to it
-from elsewhere in the draft and still have it build.
-
 --- back
 
 # Contributors
@@ -567,6 +554,10 @@ divergentdave@gmail.com
 Suman Ganta
 Apple Inc.
 sganta2@apple.com
+
+Tim Geoghegan
+ISRG
+timgeog+ietf@gmail.com
 
 Gianni Parsa
 Apple Inc.

--- a/draft-ietf-ppm-dap-taskprov.md
+++ b/draft-ietf-ppm-dap-taskprov.md
@@ -1,5 +1,5 @@
 ---
-title: "Task Binding and In-Band Provisioning for DAP"
+title: "In-Band Task Provisioning for DAP"
 abbrev: DAP-Taskprov
 category: info
 
@@ -46,12 +46,10 @@ informative:
 
 --- abstract
 
-An extension for the Distributed Aggregation Protocol (DAP) is specified that
-cryptographically binds the parameters of a task to the task's execution. In
-particular, when a client includes this extension with its report, the servers
-will only aggregate the report if all parties agree on the task parameters.
-This document also specifies an optional mechanism for in-band task
-provisioning that builds on the report extension.
+This document defines a mechanism for provisioning tasks for the Distributed
+Aggregation Protocol (DAP). The task configuration is provisioned in-band via an
+HTTP header. This document also specifies a task extension that signals to
+parties that this mechanism was used to configure the task.
 
 
 --- middle
@@ -61,53 +59,34 @@ provisioning that builds on the report extension.
 (RFC EDITOR: Remove this paragraph.) This draft is maintained in
 https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap-taskprov.
 
+> TODO: update this DAP reference once draft-ietf-ppm-dap-18 is out
+
 The DAP protocol {{!DAP=I-D.draft-ietf-ppm-dap-16}} enables secure aggregation
 of a set of reports submitted by Clients. This process is centered around a
 "task" that determines, among other things, the cryptographic scheme to use for
 the secure computation (a Verifiable Distributed Aggregation Function
 {{!VDAF=I-D.draft-irtf-cfrg-vdaf-15}}), how reports are partitioned into
 batches, and privacy parameters such as the minimum size of each batch. See
-{{Section 4.2 of !DAP}} for a complete listing.
-
-In order to execute a task securely, it is required that all parties agree on
-all parameters associated with the task. However, the core DAP specification
-does not specify a mechanism for accomplishing this. In particular, it is
-possible that the parties successfully aggregate and collect a batch, but some
-party does not know the parameters that were enforced.
-
-A desirable property for DAP to guarantee is that successful execution implies
-agreement on the task parameters. On the other hand, disagreement between a
-Client and the Aggregators should prevent reports uploaded by that Client from
-being processed.
-
-{{definition}} specifies a report extension ({{Section 4.5.3 of !DAP}}) that
-endows DAP with this property. First, it specifies an encoding of all task
-parameters that are relevant to all parties. This excludes cryptographic
-assets, such as the secret VDAF verification key ({{Section 5 of !VDAF}}) or
-the public HPKE configurations {{!RFC9180}} of the aggregators or collector.
-Second, the task ID is computed by hashing the encoded parameters. If a report
-includes the extension, then each aggregator checks if the task ID was computed
-properly: if not, it rejects the report. This cryptographic binding of the task
-to its parameters ensures that the report is only processed if the Client and
-Aggregator agree on the task parameters.
-
-One reason this task-binding property is desirable is that it makes the process
-by which parties are provisioned with task parameters more robust. This is
-because misconfiguration of a party would manifest in a server's telemetry as
-report rejection. This is preferable to failing silently, as misconfiguration
-could result in privacy loss.
+{{todo-fix-dap-reference}} for a complete listing.
 
 {{taskprov}} specifies one possible mechanism for provisioning DAP tasks that
-is built on top of the extension in {{definition}}. Its chief design goal is to
-make task configuration completely in-band, via HTTP request headers. Note that
-this mechanism is an optional feature of this specification; it is not required
-to implement the DAP report extension in {{definition}}.
+is built on top of the task configuration definition in
+{{todo-fix-dap-reference}}. Its chief design goal is to make task configuration
+completely in-band, via HTTP request headers. It also defines a task extension
+that signals to parties that this mechanism was used to configure the task.
 
 ## Change Log
 
 (RFC EDITOR: Remove this section.)
 
 (\*) Indicates a change that breaks wire compatibility with the previous draft.
+
+05:
+
+- Task binding is moved to {{!DAP}}
+  (https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/774).  (\*)
+
+- Move report extension to a task extension to make reports smaller.  (\*)
 
 04:
 
@@ -180,248 +159,50 @@ error types:
 The terms used follow those described in {{!DAP}}. The following new terms are
 used:
 
-Task configuration:
-: The non-secret parameters of a task.
-
 Task author:
 : The entity that defines a task's configuration in the provisioning mechanism of {{taskprov}}.
 
-# The Taskprov Extension {#definition}
+# The Taskprov Task Extension {#definition}
 
-To use the Taskprov extension, the Client includes the following extension in
-the report extensions for each Aggregator as described in {{Section 4.5.3 of
-!DAP}}:
-
-~~~
-enum {
-    taskprov(0xff00),
-    (2^16-1)
-} ExtensionType;
-~~~
+When Taskprov is in use, protocol participants include a `Taskprov` extension
+(see {{task-extension}}) in the task's `TaskConfiguration` structure as
+described in {{todo-fix-dap-reference}}.
 
 The payload of the extension MUST be empty. If the payload is non-empty, then
-the Aggregator MUST reject the report.
+the protocol participant MUST refuse to participate in the task.
 
-When the client uses the Taskprov extension, it computes the task ID ({{Section
-4.2 of !DAP}}) as follows:
+When the client uses the Taskprov extension, it computes the task ID
+({{todo-fix-dap-reference}}) as follows:
 
 ~~~
 task_id = SHA-256(SHA-256("dap-taskprov task id") || task_config)
 ~~~
 
-where `task_config` is a `TaskConfig` structure defined in {{task-encoding}}.
-Function SHA-256() is as defined in {{SHS}}.
+where `task_config` is a `TaskConfiguration` structure defined in
+{{todo-fix-dap-reference}}. Function SHA-256() is as defined in {{SHS}}.
 
-The task ID is bound to each report share (via HPKE authenticated and
-associated data, see {{Section 4.5.2 of !DAP}}). Binding the parameters to the
-ID this way ensures, in turn, that the report is only aggregated if the Client
-and Aggregator agree on the parameters. This is accomplished by the Aggregator
-behavior below.
+The task configuration is bound to each report share (via HPKE authenticated and
+associated data, see {{todo-fix-dap-reference}}). Deterministically deriving the
+task ID from the encoded `TaskConfiguration` ensures that Clients, Aggregators
+and the Collector can only agree on the task ID if they also agree on the
+parameters, including whether Taskprov is in use. This is accomplished by the
+following Aggregator behavior.
 
-During aggregation ({{Section 4.6 of !DAP}}), each Aggregator processes a
-report with the Taskprov extension as follows.
+During aggregation ({{Section 4.6 of !DAP}}) in a task where Taskprov is in use,
+each Aggregator processes reports as follows.
 
 First, it looks up the ID and parameters associated with the task. Note the
 task has already been configured; otherwise the Aggregator would have already
 aborted the request due to not recognizing the task.
 
-Next, the Aggregator encodes the parameters as a `TaskConfig` defined in
-{{task-encoding}} and computes the task ID as above. If the derived task ID
-does not match the task ID of the request, then it MUST reject the report with
-error "invalid_message".
+Next, the Aggregator encodes the parameters as a `TaskConfiguration` defined in
+{{todo-fix-dap-reference}} and computes the task ID as above. If the derived
+task ID does not match the task ID of the request, then it MUST reject the
+report with error "invalid_message".
 
 During the upload interaction ({{Section 4.5 of !DAP}}), the Leader SHOULD
 abort the request with "unrecognizedTask" if the derived task ID does not match
 the task ID of the request.
-
-## Task Encoding {#task-encoding}
-
-The task configuration is encoded as follows:
-
-~~~
-uint32 VdafType; /* As defined in Section 10 of [VDAF] */
-
-struct {
-    /* Info specific for a task. */
-    opaque task_info<1..2^8-1>;
-
-    /* Leader API endpoint. */
-    Url leader_aggregator_endpoint;
-
-    /* Helper API endpoint. */
-    Url helper_aggregator_endpoint;
-
-    /* Time precision. */
-    TimePrecision time_precision;
-
-    /* Minimum batch size. */
-    uint32 min_batch_size;
-
-    /* The batch mode and its parameters. */
-    BatchMode batch_mode;
-    opaque batch_config<0..2^16-1>;
-
-    /* The earliest timestamp that will be accepted for this task. */
-    Time task_start;
-
-    /* The duration of the task. */
-    Duration task_duration;
-
-    /* Determines the VDAF type and its config parameters. */
-    VdafType vdaf_type;
-    opaque vdaf_config<0..2^16-1>;
-
-    /* Taskprov Extensions. */
-    TaskprovExtension extensions<0..2^16-1>;
-} TaskConfig;
-~~~
-
-The purpose of `TaskConfig` is to define all parameters that are necessary for
-configuring each party. It includes all parameters listed in {{Section 4.2 of
-!DAP}} as well as two additional fields:
-
-* `task_info` is an opaque field whose contents are specific to the deployment.
-  For example, this might be a human-readable string describing the purpose of
-  this task.
-
-* `extensions` is a list of extensions to this document. The format and
-  semantics of extensions are describe in {{taskprov-extensions}}.
-
-This structure does not include cryptographic assets shared by only a subset of
-the parties, including the secret VDAF verification key {{!VDAF}} or public
-HPKE configurations {{!RFC9180}}.
-
-The `batch_mode` field indicates the DAP batch mode and corresponds to a
-codepoint in the Batch Modes Registry.
-
-> TODO Add a reference to the IANA registry for batch modes created by
-> {{!DAP}}.
-
-The `batch_config` field contains any parameters that are required for
-configuring the batch mode. For the time-interval and leader-selected batch
-modes specified in {{!DAP}}, the payload is empty. Batch modes defined by
-future documents may specify a non-empty payload; see {{extending-this-doc}}
-for details. The length prefix of the `batch_config` ensures that the batch
-config can be decoded even if the batch mode is unrecognized.
-
-The `vdaf_type` field indicates the VDAF for the task and corresponds to a
-codepoint in the VDAF Identifiers registry.
-
-> TODO: Add a reference to the IANA registry created by {{!VDAF}}.
-
-The `vdaf_config` field contains parameters necessary to configure an instance
-of the VDAF. {{vdaf-config}} defines a suitable encoding of the configuration
-for each VDAF specified in {{!VDAF}}. VDAFs defined by future documents may
-also use this field as well; see {{extending-this-doc}} for details.
-
-The length prefix of the `vdaf_config` ensures that VDAF config can be decoded
-even if the VDAF type is not recognized.
-
-The definition of `Time`, `Duration`, `Url`, and `BatchMode` follow those in
-{{!DAP}}.
-
-The `time_precision` field of a task is used in calculating all `Time`s and
-`Duration`s within the task. {{Section 4.1.1 of !DAP}}
-
-~~~
-uint64 TimePrecision;
-~~~
-
-The `TimePrecision` type represents a nonzero number of seconds.
-
-## VDAF config {#vdaf-config}
-
-This section defines the payload of `TaskConfig.vdaf_config` for each VDAF
-specified in {{!VDAF}}. In some cases, the VDAF supports more than two
-Aggregators; but since DAP only supports two Aggregators, we do not include the
-number of Aggregators in the encoding.
-
-### Prio3Count
-
-The payload is empty.
-
-### Prio3Sum
-
-~~~
-struct {
-    uint32 max_measurement; /* largest summand */
-} Prio3SumConfig;
-~~~
-
-### Prio3SumVec
-
-~~~
-struct {
-    uint32 length;       /* length of the vector */
-    uint8 bits;          /* bit length of each summand */
-    uint32 chunk_length; /* size of each proof chunk */
-} Prio3SumVecConfig;
-~~~
-
-### Prio3Histogram
-
-~~~
-struct {
-    uint32 length;       /* number of buckets */
-    uint32 chunk_length; /* size of each proof chunk */
-} Prio3HistogramConfig;
-~~~
-
-### Prio3MultihotCountVec
-
-~~~
-struct {
-    uint32 length;       /* length of the vector */
-    uint32 chunk_length; /* size of each proof chunk */
-    uint32 max_weight;   /* largest vector weight /
-} Prio3MultihotCountVecConfig;
-~~~
-
-### Poplar1
-
-~~~
-struct {
-    uint16 bits; /* bit length of the input string */
-} Poplar1Config;
-~~~
-
-## Extensions {#taskprov-extensions}
-
-The `TaskConfig` structure includes a list of extensions. In general,
-extensions can be used to bind additional, application-specific information to
-the task. For example, an extension might be used to encode the identity of the
-Collector. (Only the Aggregators are identified in `TaskConfig`.)
-
-Each extension is structured as follows:
-
-~~~ tls-presentation
-struct {
-  TaskprovExtensionType extension_type;
-  opaque extension_data<0..2^16-1>;
-} TaskprovExtension;
-
-enum {
-  reserved(0),
-  (2^16-1)
-} TaskprovExtensionType;
-~~~
-
-The `extension_type` identifies the extension and `extension_data` is
-structured as specified by the extension.
-
-Extensions are treated as mandatory-to-implement in the protocol described in
-{{taskprov}}. In particular, protocols participants MUST opt-out of tasks
-containing unrecognized extensions. See {{provisioning-a-task}}.
-
-If the same extension type appears more than once among the Taskprov extensions
-in the `TaskConfig` structure, then protocols participants MUST opt-out of tasks
-with repeated extensions.
-
-Note that Taskprov extensions are semantically distinct from DAP report
-extensions and do not share the same codepoint registry
-({{taskprov-extension-registry}}). Future documents may want to define both a
-Taskprov extension and a report extension, but there may also be situations
-where a document defines one but not the other.
 
 # In-band Task Provisioning with the Taskprov Extension {#taskprov}
 
@@ -442,7 +223,7 @@ is incumbent on all protocol participants to verify the task configuration
 disseminated by the Author and opt-out if the parameters are deemed insufficient
 for privacy. In particular, adopters of this mechanism should presume the
 Author is under the adversary's control. In fact, we expect in a real-world
-deployment that the Author may be co-located with the Collector.
+deployment that the Author may be co-located with the Collector.
 
 The DAP protocol also requires configuring the entities with a variety of assets
 that are not task-specific, but are important for establishing
@@ -482,9 +263,9 @@ configuration and decide whether to opt-in; if not, the task's execution halts.
 
 To advertise a task to its peer, a protocol participant includes the header
 "DAP-Taskprov" with an HTTP request incident to the task execution. The value
-is the `TaskConfig` structure defined {{task-encoding}}, expanded into its
-URL-safe, unpadded Base 64 representation as specified in {{Sections 5 and 3.2
-of !RFC4648}}.
+is the `TaskConfiguration` structure defined {{todo-fix-dap-reference}},
+expanded into its URL-safe, unpadded Base 64 representation as specified in
+{{Sections 5 and 3.2 of !RFC4648}}.
 
 ## Deriving the VDAF Verification Key {#vdaf-verify-key}
 
@@ -518,8 +299,8 @@ with `SHA-256()` as defined in {{SHS}}.
 ## Opting into a Task {#provisioning-a-task}
 
 Prior to participating in a task, each protocol participant must determine if
-the `TaskConfig` disseminated by the Author can be configured. The participant
-is said to "opt in" to the task if the derived task ID (see
+the `TaskConfiguration` disseminated by the Author can be configured. The
+participant is said to "opt in" to the task if the derived task ID (see
 {{definition}}) corresponds to an already configured task or the task ID
 is unrecognized and therefore corresponds to a new task.
 
@@ -534,40 +315,34 @@ A protocol participant MAY "opt out" of a task if:
 1. A secure connection to one or both of the Aggregator endpoints could not be
    established.
 
-1. The task lifetime is too long.
+1. The task lifetime is too long (if the `task_interval` task extension is in
+   use; see {{todo-fix-dap-reference}}).
 
 A protocol participant MUST opt out if:
 
-1. The task has ended.
+1. The task has ended (if the `task_interval` task extension is in use; see
+   {{todo-fix-dap-reference}}).
 
 1. The DAP batch mode or VDAF is not implemented.
-
-1. One of the extensions is not recognized.
-
-1. One of the extension types appear more than once.
 
 The behavior of each protocol participant is determined by whether or not they
 opt in to a task.
 
 ## Client Behavior
 
-Upon receiving a `TaskConfig` from the Author, the Client decides whether to
-opt into the task as described in {{provisioning-a-task}}. If the Client opts
+Upon receiving a `TaskConfiguration` from the Author, the Client decides whether
+to opt into the task as described in {{provisioning-a-task}}. If the Client opts
 out, it MUST NOT attempt to upload reports for the task.
 
 Once the client opts into a task, it may begin uploading reports for the task to
-the Leader. The extension codepoint `taskprov` MUST be offered in both the
-Leader and the Helper's report extensions. The extension may be included in
-either the public or private report extensions; it is RECOMMENDED that the
-extension be included in the public extensions. In addition, each report's task
-ID MUST be computed as described in {{definition}}.
+the Leader.
 
 The Client SHOULD advertise the task configuration by specifying the encoded
-`TaskConfig` described in {{definition}} in the "DAP-Taskprov" HTTP header, but
-MAY choose to omit this header in order to save network bandwidth. However, the
-Leader may respond with "unrecognizedTask" if it has not been configured with
-this task. In this case, the Client MUST retry the upload request with the
-"DAP-Taskprov" HTTP header.
+`TaskConfiguration` described in {{definition}} in the "DAP-Taskprov" HTTP
+header, but MAY choose to omit this header in order to save network bandwidth.
+However, the Leader may respond with "unrecognizedTask" if it has not been
+configured with this task. In this case, the Client MUST retry the upload
+request with the "DAP-Taskprov" HTTP header.
 
 ## Leader Behavior
 
@@ -596,10 +371,6 @@ The Leader then decides whether to opt in to the task as described in
 
 Finally, once the Leader has opted in to the task, it completes the upload
 request as usual.
-
-During the upload flow, if the Leader's report share does not present a
-`taskprov` extension type, the Leader MUST abort the upload request with
-"invalidMessage".
 
 ### Aggregation Protocol
 
@@ -636,30 +407,28 @@ First, the Helper attempts to parse payload of the "DAP-Taskprov" HTTP header.
 If this step fails, the Helper MUST abort with "invalidMessage".
 
 Next, the Helper checks that the task ID indicated in the request matches the
-task ID derived from the `TaskConfig` as defined in {{definition}}. If not, the
-Helper MUST abort with "unrecognizedTask".
+task ID derived from the `TaskConfiguration` as defined in
+{{todo-fix-dap-reference}}. If not, the Helper MUST abort with
+"unrecognizedTask".
 
 Next, the Helper decides whether to opt in to the task as described in
 {{provisioning-a-task}}. If it opts out, it MUST abort the request with
 "invalidTask".
 
 Finally, the Helper completes the request as usual, deriving the VDAF
-verification key for the task as described in {{vdaf-verify-key}}. During an
-aggregation job, for any report share that does not include the `taskprov`
-extension with an empty payload, the Helper MUST mark the report as invalid
-with error "invalid_message" and reject it.
+verification key for the task as described in {{vdaf-verify-key}}.
 
 ## Collector Behavior
 
-Upon receiving a `TaskConfig` from the Author, the Collector first decides
-whether to opt into the task as described in {{provisioning-a-task}}. If the
-Collector opts out, it MUST NOT attempt to initialize collection jobs for the
-task.
+Upon receiving a `TaskConfiguration` from the Author, the Collector first
+decides whether to opt into the task as described in {{provisioning-a-task}}. If
+the Collector opts out, it MUST NOT attempt to initialize collection jobs for
+the task.
 
 Otherwise, once opted in, the Collector MAY begin to issue collect requests for
-the task. The task ID for each request MUST be derived from the `TaskConfig` as
-described in {{provisioning-a-task}}. The Collector MUST advertise the task as
-described in {{task-advertisement}}.
+the task. The task ID for each request MUST be derived from the
+`TaskConfiguration` as described in {{provisioning-a-task}}. The Collector MUST
+advertise the task as described in {{task-advertisement}}.
 
 If the Leader responds to a collection request with an "unrecognizedTask"
 error, the Collector MAY retry its request after waiting an appropriate
@@ -671,8 +440,8 @@ The Taskprov extension has the same security and privacy considerations as the
 core DAP protocol. In addition, successful execution of a DAP task implies
 agreement on the task configuration. This is provided by binding the
 parameters to the task ID, which in turn is bound to each report uploaded for a
-task. Furthermore, inclusion of the Taskprov extension in the report means
-Aggregators that do not implement this extension will reject the report as
+task. Furthermore, inclusion of the Taskprov extension in the task configuration
+means Aggregators that do not implement this extension will reject the report as
 required by ({{Section 4.5.3 of !DAP}}).
 
 The task provisioning mechanism in {{taskprov}} extends the threat model of DAP
@@ -701,8 +470,8 @@ directly impact tasks used by honest Clients, it does present a
 Denial-of-Service risk for the Aggregators themselves. This can be mitigated by
 limiting the rate at which new tasks are configured. In addition, deployments
 SHOULD arrange for the Author to digitally sign the task configuration so that
-Clients cannot forge task creation, e.g., via an extension to Taskprov
-({{taskprov-extensions}}).
+Clients cannot forge task creation, e.g., via a task extension
+({{todo-fix-dap-reference}}).
 
 Support for the Taskprov extension may render a deployment of DAP more
 susceptible to task enumeration attacks ({{Section 8.6.1 of !DAP}}). For
@@ -716,8 +485,9 @@ these kinds of attack by:
 
 1. Enforcing rate limits on unauthenticated APIs; or
 
-1. Including entropy in the `task_info` field of the `TaskConfig` in order to
-   make the task ID harder to predict (e.g., 16 bytes of output of a CSPRNG).
+1. Including entropy in the `task_info` field of the `TaskConfiguration` in
+   order to make the task ID harder to predict (e.g., 16 bytes of output of a
+   CSPRNG).
 
 # Operational Considerations
 
@@ -736,47 +506,24 @@ out once they have opted in.
 
 # IANA Considerations
 
-This document requests a codepoint for the `taskprov` report extension and for
-creation of a new registry for Taskprov extensions.
+This document requests a codepoint for the `taskprov` task extension.
 
 (RFC EDITOR: Replace "XXXX" with the RFC number assigned to this document.)
 
-## Report Extension
+## Task Extension
 
 The following entry will be (RFC EDITOR: change "will be" to "has been") added
-to the "Report Extension Identifiers" registry of the "Distributed Aggregation
+to the "DAP Task Extension Identifiers" registry of the "Distributed Aggregation
 Protocol (DAP)" page created by {{!DAP}}:
 
 Value:
-: `0xff00`
+: `0x0002`
 
 Name:
 : `taskprov`
 
 Reference:
-: RFC XXXX
-
-## Registry for Taskprov Extensions {#taskprov-extension-registry}
-
-A new registry will be (RFC EDITOR: change "will be" to "has been") created for
-the "Distributed Aggregation Protocol (DAP)" page called "Taskprov Extensions".
-This registry contains the following columns:
-
-Value:
-: The two-byte identifier for the extension
-
-Name:
-: The name of the extension
-
-Reference:
-: Where the mechanism is defined
-
-The initial contents of this registry are listed in the following table.
-
-| Value    | Name       | Reference                     |
-|:---------|:-----------|:------------------------------|
-| `0x0000` | `reserved` | {{taskprov-extensions}} of RFC XXXX |
-{: #taskprov-extension-id title="Initial contents of the Taskprov Extensions registry."}
+: {{definition}} of RFC XXXX
 
 ## DAP Sub-namespace for DAP
 
@@ -795,22 +542,14 @@ task-provisioning header:
 | DAP-Taskprov | permanent | {{taskprov}} of RFC XXXX |
 {: #http-header title="Updates to the Hypertext Transfer Protocol (HTTP) Field Name Registry"}
 
-# Extending this Document {#extending-this-doc}
+# TODO fix DAP reference
 
-The behavior of the `taskprov` extension may be extended by future documents
-that define:
+> TODO: delete this section
 
-1. A new DAP batch mode
-1. A new VDAF
-1. A new Taskprov extension
-
-Documents defining either a new DAP batch mode or VDAF SHOULD include a section
-titled "Taskprov Considerations" that specifies the payload of
-`TaskConfig.batch_config` or `TaskConfig.vdaf_config` respectively.
-
-Note that the registry for batch modes is defined by {{!DAP}}; the registry for
-VDAFs is defined by {{!VDAF}}; and the registry for Taskprov extensions is defined in
-{{taskprov-extension-registry}} of this document.
+This document should refer to sections of a DAP draft that includes
+https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/774 (this will probably
+be draft-ietf-ppm-dap-18). This section is a placeholder so we can refer to it
+from elsewhere in the draft and still have it build.
 
 --- back
 


### PR DESCRIPTION
PPM WG consensus is that we should do task configuration binding/commitment in DAP itself. This is realized in [1]. This PR on taskprov mostly deletes content that now lives in draft-ietf-ppm-dap, leaving the in-band task provisioning mechanism. A couple things to call out:

- numerous portions of this document need to refer to DAP's discussion of task configuration, but since no draft including that is yet published, I put in a dummy section titled "TODO fix dap reference" and refer to that elsewhere. Once draft-ietf-ppm-dap-18 is released, we can replace those with specific section references, but for now, this gets us a buildable document we can review. A subsequent PR will replace these with up-to-date references to specific sections of draft-ietf-ppm-dap-18.
- Since the task configuration mechanism in DAP also has extensions, taskprov doesn't need to define its own extension mechanism. And to my reading, the entire section on extending taskprov can be deleted, as its considerations now apply to DAP itself.
- The taskprov *report* extension is replaced with a *task* extension. This achieves the same goal of ensuring all protocol participants agree that taskprov is in use, but avoids making every report bigger.

[1]: ietf-wg-ppm/draft-ietf-ppm-dap#774