### PR TITLE
Remove the task extension altogether

### DIFF
--- a/draft-ietf-ppm-dap-taskprov.md
+++ b/draft-ietf-ppm-dap-taskprov.md
@@ -47,10 +47,12 @@ informative:
 --- abstract
 
 This document defines a mechanism for provisioning tasks for the Distributed
-Aggregation Protocol (DAP). The task configuration is provisioned in-band via an
-HTTP header. This document also specifies a task extension that signals to
-parties that this mechanism was used to configure the task.
-
+Aggregation Protocol (DAP). The parameters of the task being executed are
+piggy-backed on each request, enabling deployment scenarios in which the
+process of provisioning these parameters is fully automated. Long-lived
+cryptographic assets are still exchanged out-of-band: accordingly, this
+document also specifies a mechanism for deriving a per-task VDAF verification
+key from a pre-shared secret.
 
 --- middle
 
@@ -66,11 +68,15 @@ scheme to use for the secure computation (a Verifiable Distributed Aggregation
 Function {{!VDAF=I-D.draft-irtf-cfrg-vdaf-15}}), how reports are partitioned
 into batches, and privacy parameters such as the minimum size of each batch.
 
-{{taskprov}} specifies one possible mechanism for provisioning DAP tasks that is
-built on top of the task configuration definition in {{Section 4.2 of !DAP}}.
-Its chief design goal is to make task configuration completely in-band, via HTTP
-request headers. It also defines a task extension that signals to parties that
-this mechanism was used to configure the task.
+This document specifies a mechanism for provisioning DAP tasks that is built on
+top of the task configuration definition in {{Section 4.2 of !DAP}}. Its chief
+design goal is to make task configuration completely in-band, via HTTP request
+headers. Long-level cryptographic assets, such as HPKE configurations
+{{?RFC9180}} and VDAF verification keys {{Section 5.2 of !VDAF}}, are presumed
+to be established out-of-band. Accordingly, this document specifies a mechanism
+for deriving a per-task verification key from a pre-shared secret in a manner
+that satisfies the security requirements for this key ({{Section 9.1 of
+!VDAF}}).
 
 ## Change Log
 
@@ -78,17 +84,12 @@ this mechanism was used to configure the task.
 
 (\*) Indicates a change that breaks wire compatibility with the previous draft.
 
-05:
-
-- Task binding is moved to {{!DAP}}
-  (https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/774).  (\*)
-
-- Move report extension to a task extension to make reports smaller.  (\*)
-
 04:
 
-- Redefine `time_precision` as its own `TimePrecision` type, to maintain
-  compatibility with DAP-16 {{!DAP}}.
+- Move task binding is moved to {{!DAP}}
+  (https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap/pull/774).  (\*)
+
+- Remove the report extension.  (\*)
 
 03:
 
@@ -146,7 +147,7 @@ this mechanism was used to configure the task.
 
 This document uses the same conventions for error handling as {{!DAP}}. In
 addition, this document extends the core specification by adding the following
-error types:
+DAP error type:
 
 | Type        | Description                                                                               |
 |:------------|:------------------------------------------------------------------------------------------|
@@ -158,48 +159,6 @@ used:
 
 Task author:
 : The entity that defines a task's configuration in the provisioning mechanism of {{taskprov}}.
-
-# The Taskprov Task Extension {#definition}
-
-When Taskprov is in use, protocol participants include a `Taskprov` extension
-(see {{task-extension}}) in the task's `TaskConfiguration` structure as
-described in {{Section 4.2 of !DAP}}.
-
-The payload of the extension MUST be empty. If the payload is non-empty, then
-the protocol participant MUST refuse to participate in the task.
-
-When the client uses the Taskprov extension, it computes the task ID ({{Section
-4.2 of !DAP}}) as follows:
-
-~~~
-task_id = SHA-256(SHA-256("dap-taskprov task id") || task_config)
-~~~
-
-where `task_config` is a `TaskConfiguration` structure. Function SHA-256() is as
-defined in {{SHS}}.
-
-The task configuration is bound to each report share (via HPKE authenticated and
-associated data, see {{Section 4.4.2.1 of !DAP}}). Deterministically deriving the
-task ID from the encoded `TaskConfiguration` ensures that Clients, Aggregators
-and the Collector can only agree on the task ID if they also agree on the
-parameters, including whether Taskprov is in use. This is accomplished by the
-following Aggregator behavior.
-
-During aggregation ({{Section 4.5 of !DAP}}) in a task where Taskprov is in use,
-each Aggregator processes reports as follows.
-
-First, it looks up the ID and parameters associated with the task. Note the
-task has already been configured; otherwise the Aggregator would have already
-aborted the request due to not recognizing the task.
-
-Next, the Aggregator encodes the parameters as a `TaskConfiguration` defined in
-{{Section 4.2 of !DAP}} and computes the task ID as above. If the derived task
-ID does not match the task ID of the request, then it MUST reject the report
-with error "invalid_message".
-
-During the upload interaction ({{Section 4.4 of !DAP}}), the Leader SHOULD
-abort the request with "unrecognizedTask" if the derived task ID does not match
-the task ID of the request.
 
 # In-band Task Provisioning with the Taskprov Extension {#taskprov}
 
@@ -227,7 +186,7 @@ that are not task-specific, but are important for establishing
 Client-Aggregator, Collector-Aggregator, and Aggregator-Aggregator
 relationships. These include:
 
-* The Collector's HPKE {{!RFC9180}} configuration used by the Aggregators to
+* The Collector's HPKE {{?RFC9180}} configuration used by the Aggregators to
   encrypt aggregate shares.
 
 * Any assets required for authenticating HTTP requests.
@@ -277,6 +236,22 @@ For example:
     DAP-Taskprov: :AWYAFGh0dHBzOi8vZXhhbXBsZS5jb20vABxodHRwczovL2Fub3RoZXIuZXhhbXBsZS5jb20vAAAAAAAAA+gAAAPoAgAAAAAAAAAAJxAAAAAAAAACXQAAAAIABAAAAP8ACAAAAAQwMTIz:
 ~~~
 
+## Deriving the DAP Task ID {#dap-task-id}
+
+When the Taskprov mechanism is in use, the task ID  ({{Section 4.2 of !DAP}} )
+is set to the hash of the task configuration. This ensures the protocol
+participants agree on the task ID before processing reports.
+
+When the DAP-Taskprov header is present, the task ID SHALL be computed as
+follows:
+
+~~~
+task_id = SHA-256(SHA-256("dap-taskprov task id") || task_config)
+~~~
+
+where `task_config` is the `TaskConfiguration` value encoded by the header.
+Function `SHA-256()` is as defined in {{SHS}}.
+
 ## Deriving the VDAF Verification Key {#vdaf-verify-key}
 
 When a Leader and Helper implement this mechanism, they SHOULD compute the
@@ -302,7 +277,7 @@ verify_key = HKDF-Expand(
 )
 ~~~
 
-where `task_id` is as defined in {{definition}}. Functions HKDF-Extract() and
+where `task_id` is as defined in {{dap-task-id}}. Functions HKDF-Extract() and
 HKDF-Expand() are as defined in {{!RFC5869}}. Both functions are instantiated
 with `SHA-256()` as defined in {{SHS}}.
 
@@ -311,7 +286,7 @@ with `SHA-256()` as defined in {{SHS}}.
 Prior to participating in a task, each protocol participant must determine if
 the `TaskConfiguration` disseminated by the Author can be configured. The
 participant is said to "opt in" to the task if the derived task ID (see
-{{definition}}) corresponds to an already configured task or the task ID
+{{dap-task-id}}) corresponds to an already configured task or the task ID
 is unrecognized and therefore corresponds to a new task.
 
 A protocol participant MAY "opt out" of a task if:
@@ -320,7 +295,8 @@ A protocol participant MAY "opt out" of a task if:
    configuration disseminated by the Author does not match the existing
    configuration.
 
-1. The VDAF config or other parameters are deemed insufficient for privacy.
+1. The VDAF configuration or other parameters are deemed insufficient for
+   privacy.
 
 1. A secure connection to one or both of the Aggregator endpoints could not be
    established.
@@ -371,8 +347,8 @@ advertisement.
 
 If the Client advertises the task, the Leader checks that the task ID indicated
 by the upload request matches the task ID derived from the DAP-Taskprov header
-value. If the task ID does not match, then the Leader MUST abort with
-"unrecognizedTask".
+value as in {{dap-task-id}}. If the task ID does not match, then the Leader
+MUST abort with "unrecognizedTask".
 
 The Leader then decides whether to opt in to the task as described in
 {{provisioning-a-task}}. If it opts out, it MUST abort the upload request with
@@ -395,9 +371,6 @@ mechanism prior to opting into the task. In this case, the Leader would need to
 abort the collect request with "unrecognizedTask". When it does so, it is up to
 the Collector to retry its request.
 
-> OPEN ISSUE: This semantics is awkward, as there's no way for the Leader to
-> distinguish between Collectors who support this mechanism and those that don't.
-
 The Leader MUST advertise the task in every aggregate share request issued to
 the Helper as described in {{task-advertisement}}.
 
@@ -413,8 +386,8 @@ it MUST abort the request with error "unrecognizedTask". Otherwise, if the
 Helper supports this mechanism, it proceeds as follows.
 
 First, the Helper checks that the task ID indicated in the request matches the
-task ID derived from the `TaskConfig` as defined in {{definition}}. If not, the
-Helper MUST abort with "unrecognizedTask".
+task ID derived from the `TaskConfiguration` as defined in {{dap-task-id}}. If
+not, the Helper MUST abort with "unrecognizedTask".
 
 Next, the Helper decides whether to opt in to the task as described in
 {{provisioning-a-task}}. If it opts out, it MUST abort the request with
@@ -432,7 +405,7 @@ the task.
 
 Otherwise, once opted in, the Collector MAY begin to issue collect requests for
 the task. The task ID for each request MUST be derived from the
-`TaskConfiguration` as described in {{provisioning-a-task}}. The Collector MUST
+`TaskConfiguration` as described in {{dap-task-id}}. The Collector MUST
 advertise the task as described in {{task-advertisement}}.
 
 If the Leader responds to a collection request with an "unrecognizedTask"
@@ -441,20 +414,11 @@ amount of time.
 
 # Security Considerations
 
-The Taskprov extension has the same security and privacy considerations as the
-core DAP protocol. In addition, successful execution of a DAP task implies
-agreement on the task configuration. This is provided by binding the
-parameters to the task ID, which in turn is bound to each report uploaded for a
-task. Furthermore, inclusion of the Taskprov extension in the task configuration
-means Aggregators that do not implement this extension will reject the report as
-required by {{Section 4.2.2 of !DAP}}.
-
-The task provisioning mechanism in {{taskprov}} extends the threat model of DAP
-by including a new logical role, called the Author. The Author is responsible
-for configuring Clients prior to task execution. For privacy we consider the
-Author to be under control of the adversary. It is therefore incumbent on
-protocol participants to verify the privacy parameters of a task before opting
-in.
+The DAP-Taskprov header extends the threat model of DAP by including a new
+logical role, called the Author. The Author is responsible for configuring
+Clients prior to task execution. For privacy we consider the Author to be under
+control of the adversary. It is therefore incumbent on protocol participants to
+verify the privacy parameters of a task before opting in.
 
 Another risk is that the Author could configure a unique task to fingerprint a
 Client. Although Client anonymization is not guaranteed by DAP, some systems
@@ -478,12 +442,11 @@ SHOULD arrange for the Author to digitally sign the task configuration so that
 Clients cannot forge task creation, e.g., via a task extension ({{Section 4.2.2
 of !DAP}}).
 
-Support for the Taskprov extension may render a deployment of DAP more
-susceptible to task enumeration attacks ({{Section 8.6.1 of !DAP}}). For
-example, if the Leader's upload endpoint is unauthenticated, then any HTTP
-client can learn if a Leader supports a particular task configuration by
-uploading a report for it with the Taskprov extension. Aggregators can mitigate
-these kinds of attack by:
+Support for DAP-Taskprov may render a deployment of DAP more susceptible to
+task enumeration attacks ({{Section 8.6.1 of !DAP}}). For example, if the
+Leader's upload endpoint is unauthenticated, then any HTTP client can learn if
+a Leader supports a particular task configuration by advertising the
+DAP-Taskrpov header. Aggregators can mitigate these kinds of attack by:
 
 1. Requiring authentication of all APIs, including the upload endpoint (see
    {{Section 3.5 of !DAP}});
@@ -496,45 +459,22 @@ these kinds of attack by:
 
 # Operational Considerations
 
-The Taskprov extension does not introduce any new operational considerations
-for DAP.
-
-The task provisioning mechanism in {{taskprov}} is designed so that the
-Aggregators do not need to store individual task configurations long-term.
-Because the task configuration is advertised in each request in the upload,
-aggregation, and collection protocols, the process of opting-in and deriving the
-task ID and VDAF verify key can be re-run on the fly for each request. This is
-useful if a large number of concurrent tasks are expected. Once an Aggregator
-has opted-in to a task, the expectation is that the task is supported until it
-ends. In particular, Aggregators that operate in this manner MUST NOT opt
-out once they have opted in.
+The DAP-Taskprv provisioning mechanism is designed so that the Aggregators do
+not need to store individual task configurations long-term. Because the task
+configuration is advertised in each request in the upload, aggregation, and
+collection flows, the process of opting-in and deriving the task ID and VDAF
+verify key can be re-run on the fly for each request. This is useful if a large
+number of concurrent tasks are expected. Once an Aggregator has opted-in to a
+task, the expectation is that the task is supported until the task expires. In
+particular, Aggregators that operate in this manner MUST NOT opt out once they
+have opted in.
 
 # IANA Considerations
 
-This document requests a codepoint for the `taskprov` task extension.
+## Updates to DAP Sub-namespace for DAP
 
-(RFC EDITOR: Replace "XXXX" with the RFC number assigned to this document.)
-
-## Task Extension
-
-The following entry will be (RFC EDITOR: change "will be" to "has been") added
-to the "DAP Task Extension Identifiers" registry of the "Distributed Aggregation
-Protocol (DAP)" page created by {{!DAP}}:
-
-Value:
-: `0x0002`
-
-Name:
-: `taskprov`
-
-Reference:
-: {{definition}} of RFC XXXX
-
-## DAP Sub-namespace for DAP
-
-> TODO Figure out how to ask IANA to register the errors in
-> {{urn-space-errors}}. See
-> https://github.com/ietf-wg-ppm/draft-ietf-ppm-dap-taskprov/issues/34
+The values in {{urn-space-errors}} will be (RFC EDITOR: change "will be" to
+"have been") added to urn:ietf:params:ppm:dap.
 
 ## HTTP Field Name Registration
 


### PR DESCRIPTION
Closes #34.
Closes #114.

Continue to derive the task ID from the config, ensuring that reports are never processed with different configs in the same task.

While at it:

1. Complete IANA considerations for the new DAP error type.

2. Demote HPKE to an informative reference.