### PR TITLE
MUST opt out if task has unrecognized extension

### DIFF
--- a/draft-ietf-ppm-dap-taskprov.md
+++ b/draft-ietf-ppm-dap-taskprov.md
@@ -315,6 +315,8 @@ A protocol participant MUST opt out if:
 
 1. The DAP batch mode or VDAF is not implemented.
 
+1. Any task extension is not recognized.
+
 The behavior of each protocol participant is determined by whether or not they
 opt in to a task.
 


### PR DESCRIPTION
DAP says that "Extensions are mandatory to support. Protocol participants MUST NOT participate in tasks containing unrecognized extensions." Thus, I think we should add this to the list of situations where opting out of a task is required.